### PR TITLE
Display contact details pulled from content store.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,18 @@ gem 'unicorn', '4.8.3'
 
 gem 'spring',      group: :development
 
+if ENV['API_DEV']
+    gem 'gds-api-adapters', :path => '../gds-api-adapters'
+else
+    gem 'gds-api-adapters', '11.0.0'
+end
+
+gem 'govuk_frontend_toolkit', "0.46.1"
+
 group :development, :test do
   gem 'rspec-rails', '2.14.2'
   gem 'capybara', '2.3.0'
+  gem 'webmock', '~> 1.18.0', :require => false
 
   gem 'simplecov-rcov', '0.2.3', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     airbrake (4.0.0)
       builder
       multi_json
@@ -39,14 +40,26 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    docile (1.1.4)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.2.0)
+    gds-api-adapters (11.0.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rest-client (~> 1.6.3)
+    govuk_frontend_toolkit (0.46.1)
+      rails (>= 3.1.0)
+      sass (>= 3.2.0)
     hike (1.2.3)
     i18n (0.6.9)
     json (1.8.1)
     kgio (2.9.2)
+    link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.5.3)
       logstash-event (~> 1.1.0)
@@ -98,6 +111,8 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
+    safe_yaml (1.0.3)
+    sass (3.2.19)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -114,7 +129,7 @@ GEM
       rack (>= 1.3.5)
       rest-client
     spring (1.1.3)
-    sprockets (2.12.1)
+    sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -131,13 +146,16 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.1)
       thread_safe (~> 0.1)
-    uglifier (2.5.0)
+    uglifier (2.5.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    webmock (1.18.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -147,6 +165,8 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   capybara (= 2.3.0)
+  gds-api-adapters (= 11.0.0)
+  govuk_frontend_toolkit (= 0.46.1)
   logstasher (= 0.5.3)
   plek (~> 1.8.1)
   rails (= 4.1.1)
@@ -156,3 +176,4 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
   unicorn (= 4.8.3)
+  webmock (~> 1.18.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
+  include Slimmer::Headers
+  include Slimmer::Template
+
   protect_from_forgery with: :exception
+
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,30 @@
+require 'gds_api/helpers'
+require 'gds_api/content_store'
+
+class ContactsController < ApplicationController
+  include GdsApi::Helpers
+
+  before_filter :set_beta_notice, only: :show
+  helper_method :organisation
+
+  def show
+    path = "/#{APP_SLUG}/#{params[:organisation]}/#{params[:id]}"
+    obj = content_store.content_item(path)
+    render :status => 404 unless obj
+    @contact = ContactPresenter.new(obj)
+  end
+
+  private
+
+  def organisation
+    @contact.organisation
+  end
+
+  def set_beta_notice
+    response.header[Slimmer::Headers::BETA_LABEL] = "after:.header-block"
+  end
+
+  def content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def page_class(css_class)
+    content_for(:page_class, css_class)
+  end
 end

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -1,0 +1,61 @@
+class ContactPresenter
+
+  attr_reader :contact
+
+  def initialize(contact, places = nil)
+    @contact = contact
+  end
+
+  PASS_THROUGH_KEYS = [
+    :title, :details, :web_url
+  ]
+
+  PASS_THROUGH_DETAILS_KEYS = [
+    :description, :organisation, :query_response_time,
+    :more_info_contact_form, :more_info_email_address, :more_info_post_address
+  ]
+
+  PASS_THROUGH_COLLECTIONS_KEYS = [
+    :quick_links, :phone_numbers, :email_addresses, :post_addresses,
+    :contact_form_links
+  ]
+
+  PASS_THROUGH_KEYS.each do |key|
+    define_method key do
+      contact[key.to_s]
+    end
+  end
+
+  PASS_THROUGH_DETAILS_KEYS.each do |key|
+    define_method key do
+      details[key.to_s] if details
+    end
+  end
+
+  PASS_THROUGH_COLLECTIONS_KEYS.each do |key|
+    define_method key do
+      if details
+        details[key.to_s].map {|item| OpenStruct.new(item)}
+      end
+    end
+  end
+
+  def format
+    @contact["format"]
+  end
+
+  def organisation
+    OpenStruct.new(details['organisation'])
+  end
+
+  def slug
+    URI.parse(web_url).path.sub(%r{\A/}, "")
+  end
+
+  def updated_at
+    date = @contact["updated_at"]
+    DateTime.parse(date) if date
+  end
+
+end
+

--- a/app/views/contacts/_contact_details.html.erb
+++ b/app/views/contacts/_contact_details.html.erb
@@ -1,0 +1,35 @@
+<% if contact.contact_form_links.any? %>
+  <div class="online-forms">
+    <h2>Online forms</h2>
+    <ul class="form-links">
+      <%= render partial: "contact_form_link", collection: contact.contact_form_links %>
+    </ul>
+    <%= contact.more_info_contact_form %>
+  </div>
+<% end -%>
+
+<% if contact.email_addresses.any? %>
+  <h2 class="details-header">Email</h2>
+  <div class="details">
+    <p class="description"><%= contact.more_info_email_address.to_s %></p>
+    <ul class="email">
+      <%= render partial: "email_address", collection: contact.email_addresses %>
+    </ul>
+  </div>
+<% end %>
+
+<% if contact.phone_numbers.any? %>
+  <h2 class="details-header">Phone</h2>
+  <div class="details">
+    <%= render partial: "phone_number", collection: contact.phone_numbers %>
+  </div>
+<% end %>
+
+<% if contact.post_addresses.any? %>
+  <h2 class="details-header">Post</h2>
+  <div class="details">
+    <%= render partial: "post_address", collection: contact.post_addresses %>
+    <%= contact.more_info_post_address %>
+  </div>
+<% end %>
+

--- a/app/views/contacts/_contact_form_link.html.erb
+++ b/app/views/contacts/_contact_form_link.html.erb
@@ -1,0 +1,3 @@
+<li class="vcard">
+  <%= link_to contact_form_link.title, contact_form_link.link, rel: 'external', class:'url fn link-underline' %>
+</li>

--- a/app/views/contacts/_email_address.html.erb
+++ b/app/views/contacts/_email_address.html.erb
@@ -1,0 +1,11 @@
+<li>
+  <div class="vcard">
+    <h3 class="fn"><%= email_address.title %></h3>
+    <p><%= mail_to email_address.email %></p>
+    <% if email_address.description.present? %>
+      <div class="email-description">
+        <%= email_address.description %>
+      </div>
+    <% end %>
+  </div>
+</li>

--- a/app/views/contacts/_phone_number.html.erb
+++ b/app/views/contacts/_phone_number.html.erb
@@ -1,0 +1,51 @@
+<% if @contact.phone_numbers.size > 1 %>
+  <h4>
+    <%= phone_number.title %>
+  </h4>
+<% end -%>
+
+<ul class="phone-list">
+  <li>
+    <span class="type">Telephone: </span>
+    <span class="value"><%= phone_number.number %></span>
+  </li>
+
+  <% if phone_number.textphone.present? %>
+    <li>
+      <span class="type">Textphone: </span>
+      <span class="value"><%= phone_number.textphone %></span>
+    </li>
+  <% end %>
+
+  <% if phone_number.international_phone.present? %>
+    <li>
+      <span class="type">Outside UK: </span>
+      <span class="value"><%= phone_number.international_phone %></span>
+    </li>
+  <% end %>
+
+  <% if phone_number.fax.present? %>
+    <li>
+      <span class="type">Fax: </span>
+      <span class="value"><%= phone_number.fax %></span>
+    </li>
+  <% end %>
+</ul>
+
+<% if phone_number.description.present? %>
+  <div class="description">
+    <%= raw phone_number.description %>
+  </div>
+<% end %>
+
+<p><%= link_to "Find out about call charges", "https://www.gov.uk/call-charges", class: "link-underline" %></p>
+
+<% if phone_number.open_hours.present? %>
+  <p class="times">Opening times:</p>
+  <%= raw phone_number.open_hours %>
+<% end %>
+
+<% if phone_number.best_time_to_call.present? %>
+  <p class="times">Best time to call:</p>
+  <%= raw phone_number.best_time_to_call %>
+<% end %>

--- a/app/views/contacts/_post_address.html.erb
+++ b/app/views/contacts/_post_address.html.erb
@@ -1,0 +1,6 @@
+<% if post_address.description.present? %>
+  <div class="description">
+    <%= govspeak post_address.description %>
+  </div>
+<% end %>
+<%= vcard_for_post_address(post_address) %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,0 +1,26 @@
+<% page_class 'contact-show' %>
+
+<header class="header-block">
+  <div class="heading">
+    <p class="type">Contact details</p>
+    <h1><%= @contact.title %></h1>
+  </div>
+
+  <% if @contact.quick_links.any? %>
+    <aside class="heading-extra">
+      <ul class="quick-links">
+        <% @contact.quick_links.each do |quick_link| %>
+          <li>
+            <%= link_to quick_link.title, quick_link.url %>
+          </li>
+        <% end %>
+      </ul>
+    </aside>
+  <% end %>
+</header>
+
+<%= render "contact_details", contact: @contact %>
+
+<% if @contact.query_response_time %>
+  <p class="response"><%= link_to "Find out when to expect a response to your query", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %></p>
+<% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,35 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= yield :title %> - GOV.UK</title>
-    <%= yield :head %>
-  </head>
-
-  <body class="<%= yield :body_classes %>">
-    <div id="wrapper" class="<%= yield :wrapper_classes %>">
+<html>
+<head>
+  <title><%= organisation.title %> contacts - GOV.UK</title>
+  <%= csrf_meta_tags %>
+</head>
+<body class="hmrc-contacts-body">
+<% unless local_assigns[:show_breadcrumbs] %>
+<div id="global-breadcrumb" class="header-context group">
+  <ol role="breadcrumbs" class="group">
+    <li>
+      <%= link_to "Home", '/' %>
+    </li>
+    <li>
+      <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>
+    </li>
+    <% if params[:action] == "show" %>
+      <li>
+        <%= link_to "Contact #{organisation.abbreviation_or_title}", "/contact/#{organisation.slug}" %>
+      </li>
+    <% end %>
+  </ol>
+</div>
+<% end %>
+<div id="wrapper">
+  <div class="hmrc-contacts-content">
+    <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>
+      <div id="report-a-problem"></div>
     </div>
-  </body>
+  </div>
+</div>
+
+</body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+APP_SLUG = 'contact'
+
 module ContactsFrontend
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-
+  get "/#{APP_SLUG}/:organisation/:id" => "contacts#show"
   get "/healthcheck" => proc {|env| [200, {}, ["OK"]] }
 end

--- a/spec/features/contact_spec.rb
+++ b/spec/features/contact_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+
+include GdsApi::TestHelpers::ContentStore
+
+describe "Show contact page" do
+  let(:path) { '/contact/hm-revenue-customs/annual-tax-on-enveloped-dwellings-ated' }
+  before :each do
+    content_store_has_item(path, contact_data)
+  end
+
+  it "displays contact details under relevant path" do
+    visit(path)
+    expect(page).to have_content(contact_data["title"])
+  end
+end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ContactPresenter do
+  let(:contact) { ContactPresenter.new(contact_data) }
+
+  it 'should access detail elements directly' do
+    expect(contact.query_response_time).to eq(false)
+    expect(contact.title).to eq('Annual Tax on Enveloped Dwellings (ATED)')
+    expect(contact.more_info_email_address).to eq('addresses that you can mail')
+  end
+
+  it "should convert collections to lists of OpenStructs" do
+    expect(contact.phone_numbers.length).to eq(1)
+    expect(contact.phone_numbers.first.number).to eq('0845 603 0135')
+    expect(contact.quick_links.length).to eq(0)
+  end
+
+  it "should access Organisation as an OpenStruct" do
+    expect(contact.organisation.abbreviation).to eq('HMRC')
+    expect(contact.organisation.slug).to eq('hm-revenue-customs')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'webmock/rspec'
+require 'slimmer/test'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/support/contact.rb
+++ b/spec/support/contact.rb
@@ -1,0 +1,65 @@
+module ContactHelper
+  def contact_data()
+    contact = {
+      "base_path" => "/contact/hm-revenue-customs/annual-tax-on-enveloped-dwellings-ated",
+     "description" => "For information and advice about ATED, who needs to complete and submit a return and make a payment",
+     "details" =>
+      {"contact_form_links" =>
+        [{"link" => "http://www.hmrc.gov.uk/ated/index.htm",
+          "title" => "Annual Tax on Enveloped Dwellings (ATED) - the basics"}],
+       "contact_groups" =>
+        [{"contacts" =>53,
+          "description" =>
+           "General Tax enquiries for individuals, employees and self-employed",
+          "organisation" =>
+           {"abbreviation" => "HMRC",
+            "format" => "Non-ministerial department",
+            "govuk_status" => "live",
+            "id" =>24,
+            "slug" => "hm-revenue-customs",
+            "title" => "HM Revenue & Customs"},
+          "title" => "Tax"}],
+       "description" =>
+        "For information and advice about ATED, who needs to complete and submit a return and make a payment",
+       "email_addresses" => [],
+       "language" => "en",
+       "more_info_contact_form" => "",
+       "more_info_email_address" => "addresses that you can mail",
+       "more_info_post_address" => "Postie data and stuff",
+       "organisation" =>
+        {"abbreviation" => "HMRC",
+         "format" => "Non-ministerial department",
+         "govuk_status" => "live",
+         "id" =>24,
+         "slug" => "hm-revenue-customs",
+         "title" => "HM Revenue & Customs"},
+       "phone_numbers" =>
+        [{"best_time_to_call" => nil,
+          "description" => "For <i>enquiries</i> relating to ATED",
+          "fax" => "03000 570 316",
+          "international_phone" => "+44 1726 209 042",
+          "number" => "0845 603 0135",
+          "open_hours" =>
+           "8.30 am to 5.00 pm Monday to Friday\r\nClosed weekends and bank holidays",
+          "textphone" =>nil,
+          "title" => "Annual Tax on Enveloped Dwellings Helpline"}],
+       "post_addresses" => [],
+       "query_response_time" =>false,
+       "quick_links" => [],
+       "slug" => "annual-tax-on-enveloped-dwellings-ated",
+       "title" => "Annual Tax on Enveloped Dwellings (ATED)"},
+     "format" => "contact",
+     "need_ids" => [],
+     "public_updated_at" => "2014-06-16T14:55:18.000Z",
+     "publishing_app" => "contacts",
+     "rendering_app" => "contacts-frontend",
+     "routes" =>
+      [{"path" => "/contact/hm-revenue-customs/annual-tax-on-enveloped-dwellings-ated",
+        "rendering_app" => "contacts-frontend",
+        "type" => "exact"}],
+     "title" => "Annual Tax on Enveloped Dwellings (ATED)",
+     "update_type" => "major"}
+  end
+end
+
+RSpec.configuration.include ContactHelper


### PR DESCRIPTION
Working implementation, except for front-end styles. Views are mostly copied
over directly from hmrc-contacts with only minor tweaks. The contact data is
loaded into a presenter to make it easier to consume in the view.
