### PR TITLE
Set a cache-control of 30 mins on show page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,11 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  private
+
+  def set_expiry(duration = 30.minutes)
+    unless Rails.env.development?
+      expires_in(duration, :public => true)
+    end
+  end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,6 +4,7 @@ require 'gds_api/content_store'
 class ContactsController < ApplicationController
   include GdsApi::Helpers
 
+  before_filter :set_expiry, only: :show
   before_filter :set_beta_notice, only: :show
   helper_method :organisation
 

--- a/spec/features/contact_spec.rb
+++ b/spec/features/contact_spec.rb
@@ -12,5 +12,6 @@ describe "Show contact page" do
   it "displays contact details under relevant path" do
     visit(path)
     expect(page).to have_content(contact_data["title"])
+    expect(page.response_headers["Cache-Control"]).to eq("max-age=1800, public")
   end
 end


### PR DESCRIPTION
The Rails default is to ser a cache-control of max-age=0, private.
These pages are cacheable, so we should set a header for efficiency.
