### PR TITLE
Fix typo in CSS class name.

### DIFF
--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_class, 'contacts-show' %>
+<% content_for :page_class, 'contact-show' %>
 <% content_for :breadcrumbs do %>
   <li>
     <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>


### PR DESCRIPTION
I made a boo-boo, and introduced a typo in c68f8d9.  This resulted in most of the CSS not applying.
