### PR TITLE
Remove handling for legacy URLs.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,2 @@
 module ApplicationHelper
-
-  # This hackery is necessary while we're supporting both the new and the legacy routes.
-  # We want the legacy contact page to link to the legacy index URL, while the new contact
-  # page should link to the new index URL
-  # FIXME: Remove this when we no longer need to support both URL schemes
-  def calculate_contacts_index_path(org)
-    if request.path.start_with?("/contact/")
-      "/contact/#{org.slug}"
-    else
-      "/government/organisations/#{org.slug}/contact"
-    end
-  end
 end

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -4,7 +4,7 @@
     <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>
   </li>
   <li>
-    <%= link_to "Contact #{organisation.abbreviation}", calculate_contacts_index_path(organisation) %>
+    <%= link_to "Contact #{organisation.abbreviation}", "/government/organisations/#{organisation.slug}/contact" %>
   </li>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,6 @@ Rails.application.routes.draw do
   with_options :format => false do |routes|
     routes.get "/government/organisations/:organisation/contact/:id" => "contacts#show"
 
-    # FIXME: Remove this route once it's no longer being used by anything
-    routes.get "/contact/:organisation/:id" => "contacts#show"
-
     routes.get "/healthcheck" => proc {|env| [200, {}, ["OK"]] }
   end
 end

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -27,22 +27,6 @@ feature "Showing a contact page" do
     expect(page.status_code).to eq(404)
   end
 
-  it "renders a contact page at the old URL" do
-    path = '/contact/hm-revenue-customs/annual-tax-on-enveloped-dwellings-ated'
-
-    content_store_has_item(path, read_content_store_fixture('hmrc_ated_legacy_url'))
-
-    visit(path)
-
-    expect(page).to have_content("Annual Tax on Enveloped Dwellings")
-    expect(page.response_headers["Cache-Control"]).to eq("max-age=1800, public")
-    expect_breadcrumb_links({
-      "Home" => "/",
-      "HM Revenue & Customs" => "/government/organisations/hm-revenue-customs",
-      "Contact HMRC" => "/contact/hm-revenue-customs",
-    })
-  end
-
   def expect_breadcrumb_links(links)
     within "#global-breadcrumb" do
       found_links = page.all("li a").map(&:text).map(&:strip)


### PR DESCRIPTION
Now that the URLs have been migrated, and redirects put in place, it's
no longer necessary to handle requests at the legacy URLs.
