### PR TITLE
Pass-on cache headers received from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
     render status: status_code, text: "#{status_code} error"
   end
 
-  def set_expiry(duration = 30.minutes)
-    unless Rails.env.development?
-      expires_in(duration, :public => true)
-    end
+  def expires_at(expiration_time = ContactsFrontend::Application.config.default_ttl.from_now)
+    response.headers['Cache-Control'] = ContactsFrontend::Application.config.cache_control_directive
+    response.headers['Expires'] = expiration_time.respond_to?(:httpdate) ? expiration_time.httpdate : expiration_time
   end
+
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,13 +4,14 @@ require 'gds_api/content_store'
 class ContactsController < ApplicationController
   include GdsApi::Helpers
 
-  before_filter :set_expiry, only: :show
   before_filter :set_beta_notice, only: :show
   helper_method :organisation
 
   def show
     obj = content_store.content_item(request.path)
     error_404 and return unless obj
+
+    expires_at(obj.headers[:expires])
     @contact = ContactPresenter.new(obj)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,9 @@ module ContactsFrontend
 
     # Disable rack::cache
     config.action_dispatch.rack_cache = nil
+
+    # Caching
+    config.cache_control_directive = 'public'
+    config.default_ttl = 30.minutes
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,8 @@ Rails.application.configure do
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.action_controller.asset_host = ENV['GOVUK_ASSET_ROOT']
   end
+
+  # Caching
+  config.cache_control_directive = 'no-cache'
+
 end

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -10,7 +10,8 @@ feature "Showing a contact page" do
     visit(path)
 
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
-    expect(page.response_headers["Cache-Control"]).to eq("max-age=1800, public")
+    expect(page.response_headers["Cache-Control"]).to eq("public")
+    expect(page.response_headers["Expires"]).to eq(content_item_cache_expiry_headers["Expires"])
     expect_breadcrumb_links({
       "Home" => "/",
       "HM Revenue & Customs" => "/government/organisations/hm-revenue-customs",
@@ -35,7 +36,8 @@ feature "Showing a contact page" do
     visit(path)
 
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
-    expect(page.response_headers["Cache-Control"]).to eq("max-age=1800, public")
+    expect(page.response_headers["Cache-Control"]).to eq("public")
+    expect(page.response_headers["Expires"]).to eq(content_item_cache_expiry_headers['Expires'])
     expect_breadcrumb_links({
       "Home" => "/",
       "HM Revenue & Customs" => "/government/organisations/hm-revenue-customs",


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4800

Caching should be controlled from the origin of
the content, so frontend apps should just proxy
it forward. This will allow us to do things like
scheduled publishing better.
