### PR TITLE
Contacts layout improvements

### DIFF
--- a/app/assets/stylesheets/views/_contact-show.scss
+++ b/app/assets/stylesheets/views/_contact-show.scss
@@ -24,11 +24,6 @@
         margin-bottom: 0  ;
       }
     }
-    .type {
-      @include core-27;
-      margin-bottom: $gutter/6;
-      color: $secondary-text-colour;
-    }
     .heading-extra {
       ul {
         padding-left: 0;
@@ -38,13 +33,29 @@
     @include media(tablet) {
       margin-bottom: $gutter;
 
-      .heading,
-      .heading-extra {
-        float: left;
+      .heading {
         width: $two-thirds;
       }
-      .heading-extra {
-        width: $one-third;
+    }
+  }
+
+  .related-positioning {
+    top: 0;
+    .related {
+      margin-top: 0;
+      padding: 0 0 $gutter 0;
+      top: 0;
+      right: $gutter;
+      @include media(tablet) {
+        width: $one-quarter;
+      }
+
+      h2 {
+        @include bold-24;
+        margin: $gutter-two-thirds 0 $gutter-one-third;
+      }
+      ul {
+        margin-bottom: $gutter;
       }
     }
   }
@@ -57,8 +68,7 @@
 
     &.details-header {
       @include media(tablet) {
-        float: left;
-        width: $one-quarter;
+        width: $two-thirds;
       }
     }
     @include media(tablet) {
@@ -68,11 +78,9 @@
 
   .details {
     margin-bottom: $gutter;
-
     @include media(tablet) {
-      float: left;
       margin-bottom: $gutter*2;
-      width: $three-quarters;
+      width: $two-thirds;
     }
 
     .times {
@@ -110,21 +118,14 @@
         @extend %contain-floats;
 
         li {
-          float: none;
           padding-bottom: $gutter-one-third;
           width: $full-width;
-
-          @include media(tablet) {
-            float: left;
-            width: $one-third;
-          }
 
           span {
             @include core-19;
             padding-right: $gutter-half;
 
             &.value {
-              display: block;
               font-weight: bold;
 
               a {
@@ -166,25 +167,6 @@
     }
   }
 
-  .quick-links {
-    li {
-      padding: 5px 0 5px 0;
-      a {
-        @include core-16;
-        font-weight: 700;
-        text-decoration: none;
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
-
-    @include media(tablet) {
-      margin-bottom: $gutter;
-    }
-  }
-
-
   .vcard {
     @include core-19;
     margin-bottom: $gutter;
@@ -199,6 +181,9 @@
     margin: $gutter 0;
     .beta {
       margin-left: 0;
+    }
+    @include media(tablet) {
+      width: $two-thirds;
     }
   }
 }

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -10,26 +10,8 @@
 
 <header class="header-block">
   <div class="heading">
-    <p class="type">Contact details</p>
     <h1><%= @contact.title %></h1>
   </div>
-
-  <% if @contact.quick_links.any? or @contact.related_links.any? %>
-    <nav class="heading-extra">
-      <ul class="quick-links">
-        <% @contact.quick_links.each do |link| -%>
-          <li>
-            <%= link_to link.title, link.url %>
-          </li>
-        <% end -%>
-        <% @contact.related_links.each do |link| -%>
-          <li>
-            <%= link_to link.title, link.web_url %>
-          </li>
-        <% end -%>
-      </ul>
-    </nav>
-  <% end %>
 </header>
 
 <%= render "contact_details", contact: @contact %>
@@ -37,3 +19,32 @@
 <% if @contact.query_response_time %>
   <p class="response"><%= link_to "Find out when to expect a response to your query", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %></p>
 <% end -%>
+
+<% if @contact.quick_links.any? or @contact.related_links.any? %>
+  <div class="related-positioning">
+    <div class="related-container">
+      <nav class="related">
+        <% if @contact.quick_links.any? %>
+          <h2 id="parent-subsection">Elsewhere on GOV.UK</h2>
+          <ul role="navigation" aria-labelledby="parent-subsection" class="quick-links">
+            <% @contact.quick_links.each do |link| -%>
+              <li>
+                <%= link_to link.title, link.url %>
+              </li>
+            <% end -%>
+          </ul>
+        <% end -%>
+        <% if @contact.related_links.any? %>
+          <h2 id="parent-subsection">Other contacts</h2>
+          <ul role="navigation" aria-labelledby="parent-subsection" class="related-links">
+            <% @contact.related_links.each do |link| -%>
+              <li>
+                <%= link_to link.title, link.web_url %>
+              </li>
+            <% end -%>
+          </ul>
+        <% end -%>
+      </nav>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -18,9 +18,11 @@ feature "Showing a contact page" do
     })
     expect_links(".quick-links", {
       "Annual Tax on Enveloped Dwellings" => "http://www.hmrc.gov.uk/ated/index.htm",
+    })
+    expect_links(".related-links", {
       "Annual tax on enveloped dwellings contact" => "http://www.hmrc.gov.uk/ated/contact.htm",
       "Another contact" => "http://www.hmrc.gov.uk/ated/another.htm"
-    })
+    })    
   end
 
   it "should 404 for a non-existent item in the content-store" do


### PR DESCRIPTION
Improvements should including surfacing related contacts in the format design

• remove p.type (Contact details) from the header and styles for that
• move related links to bottom of markup for consistent content flow for mobile
• split quick links and related links into separate lists add if statements appropriately
• move contact details to left and show in 1 column
• style in keeping with current contacts layout - https://www.gov.uk/contact-the-dvla

Related agileplanner story
https://www.agileplannerapp.com/boards/105200/cards/6316

Before and after screenshots attached -
![screen shot 2014-11-25 at 16 27 25](https://cloud.githubusercontent.com/assets/1692222/5186719/1b8238a0-74c0-11e4-9fa9-12fc0cd0a8a7.png)
![screen shot 2014-11-25 at 16 27 51](https://cloud.githubusercontent.com/assets/1692222/5186720/1b83524e-74c0-11e4-934f-dbfaafc7cc8d.png)
