### PR TITLE
Use components for beta banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.1.1'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'plek', '~> 1.8.1'
-gem 'slimmer', '~> 4.1.0'
+gem 'slimmer', '~> 6.0.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,12 +123,12 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (4.1.0)
+    slimmer (6.0.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
-      plek (>= 0.1.8)
+      plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
     spring (1.1.3)
@@ -175,7 +175,7 @@ DEPENDENCIES
   rails (= 4.1.1)
   rspec-rails (= 2.14.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (~> 4.1.0)
+  slimmer (~> 6.0.0)
   spring
   uglifier (>= 1.3.0)
   unicorn (= 4.8.3)

--- a/app/assets/stylesheets/views/_contact-show.scss
+++ b/app/assets/stylesheets/views/_contact-show.scss
@@ -176,14 +176,12 @@
     }
   }
 
+  .beta-wrapper {
+    margin: 15px 0;
 
-  .beta-label {
-    margin: $gutter 0;
-    .beta {
-      margin-left: 0;
-    }
-    @include media(tablet) {
+    @include media(desktop) {
       width: $two-thirds;
+      margin: 30px 0;
     }
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
+  include Slimmer::SharedTemplates
 
   protect_from_forgery with: :exception
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,7 +4,6 @@ require 'gds_api/content_store'
 class ContactsController < ApplicationController
   include GdsApi::Helpers
 
-  before_filter :set_beta_notice, only: :show
   helper_method :organisation
 
   def show
@@ -19,10 +18,6 @@ class ContactsController < ApplicationController
 
   def organisation
     @contact.organisation
-  end
-
-  def set_beta_notice
-    response.header[Slimmer::Headers::BETA_LABEL] = "after:.header-block"
   end
 
   def content_store

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -14,6 +14,10 @@
   </div>
 </header>
 
+<div class="beta-wrapper">
+  <%= render 'govuk_component/beta_label' %>
+</div>
+
 <%= render "contact_details", contact: @contact %>
 
 <% if @contact.query_response_time %>


### PR DESCRIPTION
Switch to using govuk_components for the beta banner rather than the
slimmer variant.

Upgraded slimmer to the latest version so that components were
available.

Introduced a beta-wrapper to ensure the beta bar is correctly placed on
the page at the right width with the right margins.