### PR TITLE
Update for new slimmer template updates

### DIFF
--- a/app/assets/stylesheets/views/_contact-show.scss
+++ b/app/assets/stylesheets/views/_contact-show.scss
@@ -32,31 +32,6 @@
 
     @include media(tablet) {
       margin-bottom: $gutter;
-
-      .heading {
-        width: $two-thirds;
-      }
-    }
-  }
-
-  .related-positioning {
-    top: 0;
-    .related {
-      margin-top: 0;
-      padding: 0 0 $gutter 0;
-      top: 0;
-      right: $gutter;
-      @include media(tablet) {
-        width: $one-quarter;
-      }
-
-      h2 {
-        @include bold-24;
-        margin: $gutter-two-thirds 0 $gutter-one-third;
-      }
-      ul {
-        margin-bottom: $gutter;
-      }
     }
   }
 
@@ -66,11 +41,6 @@
     font-weight: 700;
     margin: $gutter*1.5 0 $gutter-one-third;
 
-    &.details-header {
-      @include media(tablet) {
-        width: $two-thirds;
-      }
-    }
     @include media(tablet) {
       margin: 0 0 $gutter;
     }
@@ -80,7 +50,6 @@
     margin-bottom: $gutter;
     @include media(tablet) {
       margin-bottom: $gutter*2;
-      width: $two-thirds;
     }
 
     .times {
@@ -180,7 +149,6 @@
     margin: 15px 0;
 
     @include media(desktop) {
-      width: $two-thirds;
       margin: 30px 0;
     }
   }

--- a/app/assets/stylesheets/views/_layout.scss
+++ b/app/assets/stylesheets/views/_layout.scss
@@ -7,7 +7,6 @@
   padding-bottom: $gutter;
   background: transparent;
   color: $text-colour;
-  border-bottom: $gutter-one-third solid $govuk-blue;
 
   @include media(desktop) {
     padding-bottom: $gutter*2;

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,4 +1,3 @@
-<% content_for :page_class, 'contact-show' %>
 <% content_for :breadcrumbs do %>
   <li>
     <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>
@@ -8,47 +7,51 @@
   </li>
 <% end %>
 
-<header class="header-block">
-  <div class="heading">
-    <h1><%= @contact.title %></h1>
+<div class="grid-row">
+<main id="content" class="contact-show">
+  <header class="header-block">
+    <div class="heading">
+      <h1><%= @contact.title %></h1>
+    </div>
+  </header>
+
+  <div class="beta-wrapper">
+    <%= render 'govuk_component/beta_label' %>
   </div>
-</header>
 
-<div class="beta-wrapper">
-  <%= render 'govuk_component/beta_label' %>
-</div>
+  <%= render "contact_details", contact: @contact %>
 
-<%= render "contact_details", contact: @contact %>
-
-<% if @contact.query_response_time %>
-  <p class="response"><%= link_to "Find out when to expect a response to your query", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %></p>
-<% end -%>
-
+  <% if @contact.query_response_time %>
+    <p class="response"><%= link_to "Find out when to expect a response to your query", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %></p>
+  <% end -%>
+</main>
 <% if @contact.quick_links.any? or @contact.related_links.any? %>
-  <div class="related-positioning">
-    <div class="related-container">
-      <nav class="related">
-        <% if @contact.quick_links.any? %>
-          <h2 id="parent-subsection">Elsewhere on GOV.UK</h2>
-          <ul role="navigation" aria-labelledby="parent-subsection" class="quick-links">
+  <div class="related-container">
+    <div class="related" id="related">
+      <% if @contact.quick_links.any? %>
+        <h2 id="elsewhwere-on-govuk">Elsewhere on GOV.UK</h2>
+        <nav role="navigation" labeled-by="elsewhere-on-govuk">
+          <ul class="quick-links">
             <% @contact.quick_links.each do |link| -%>
               <li>
                 <%= link_to link.title, link.url %>
               </li>
             <% end -%>
           </ul>
-        <% end -%>
-        <% if @contact.related_links.any? %>
-          <h2 id="parent-subsection">Other contacts</h2>
-          <ul role="navigation" aria-labelledby="parent-subsection" class="related-links">
+        </nav>
+      <% end -%>
+      <% if @contact.related_links.any? %>
+        <h2 id="other-contacts">Other contacts</h2>
+        <nav role="navigation" aria-labelledby="other-contacts">
+          <ul class="related-links">
             <% @contact.related_links.each do |link| -%>
               <li>
                 <%= link_to link.title, link.web_url %>
               </li>
             <% end -%>
           </ul>
-        <% end -%>
-      </nav>
+        </nav>
+      <% end -%>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
The template is changing to auto-center and provide layout to pages.
This makes these pages ready for that change.

Updated the related element to actually match the markup from the static
version. It had a couple of enhancements over the version that was here
like having the aria-labelled by actually pointing to the right
headings.

It also adds a main element to the page which is used for the layout in
static.

This is related to this pull request on static: https://github.com/alphagov/static/pull/530