### PR TITLE
Bump slimmer for new rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.1.1'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'plek', '~> 1.8.1'
-gem 'slimmer', '8.2.0'
+gem 'slimmer', '8.2.1'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -175,7 +175,7 @@ DEPENDENCIES
   rails (= 4.1.1)
   rspec-rails (= 2.14.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 8.2.0)
+  slimmer (= 8.2.1)
   spring
   uglifier (>= 1.3.0)
   unicorn (= 4.8.3)


### PR DESCRIPTION
This now uses the GOVUK_APP_NAME env variable rather than the
application class name so it can be cross referenced to other things in
the stack.

This contains https://github.com/alphagov/slimmer/pull/128