### PR TITLE
Add meta description tag for contacts

### DIFF
--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <% if @contact.description.present? %>
+    <meta name='description' content='<%= @contact.description %>' />
+  <% end %>
+<% end %>
+
 <% content_for :breadcrumbs do %>
   <li>
     <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
   <%= csrf_meta_tags %>
+  <%= yield :extra_headers %>
 </head>
 <body class="contacts-body">
 

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -9,6 +9,7 @@ feature "Showing a contact page" do
 
     visit(path)
 
+    expect(page).to have_selector("meta[name='description'][content='Help about ATED (previously called Annual Residential Property Tax), who needs to submit a return and how to make a payment']", visible: false)
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
     expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")
     expect_links("#global-breadcrumb", {


### PR DESCRIPTION
Part of improving search result snipperts shown on external search engines.

The lack of a meta-description tag makes some search result snippets unhelpful, confusing, or misleading. Ticket: https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types