### PR TITLE
Set slimmer template to be wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.1.11'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'plek', '~> 1.11'
-gem 'slimmer', '8.2.1'
+gem 'slimmer', '9.0.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -177,7 +177,7 @@ DEPENDENCIES
   rails (= 4.1.11)
   rspec-rails (= 2.14.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   spring
   uglifier (>= 1.3.0)
   unicorn (= 4.8.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,10 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::Template
   include Slimmer::SharedTemplates
 
   protect_from_forgery with: :exception
+
+  slimmer_template 'wrapper'
 
   private
 


### PR DESCRIPTION
Explicitly set the slimmer template to be wrapper so that it isn't
effected by changes to the default when slimmer is updated.