### PR TITLE
Set a correct title for contact pages

### DIFF
--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -4,6 +4,8 @@
   <% end %>
 <% end %>
 
+<% content_for :page_title, "#{@contact.title} - Contact #{organisation.abbreviation}" %>
+
 <% content_for :breadcrumbs do %>
   <li>
     <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= organisation.title %> contacts - GOV.UK</title>
+  <title><%= yield :page_title %> - GOV.UK</title>
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application.css" %><!--<![endif]-->
     <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -9,6 +9,7 @@ feature "Showing a contact page" do
 
     visit(path)
 
+    expect(page).to have_title 'Annual Tax on Enveloped Dwellings - Contact HMRC - GOV.UK'
     expect(page).to have_selector("meta[name='description'][content='Help about ATED (previously called Annual Residential Property Tax), who needs to submit a return and how to make a payment']", visible: false)
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
     expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")


### PR DESCRIPTION
Contact pages all have the same `<title>` tag: "{organisation.title} contacts". There are 133 HMRC pages that have the same title, which causes google to correct them to something unique:

![screen shot 2015-08-27 at 14 32 39](https://cloud.githubusercontent.com/assets/233676/9521736/7d5a2bce-4cc8-11e5-90cf-51f5a3c4d05b.png)
(note that Google doesn't use the correct capitalisation of "GOV.UK" - that's how you can see Google has modified the title)

This commit changes the page title to the form

> "Air Passenger Duty - Contact HMRC - GOV.UK"

## Before


![screen shot 2015-08-27 at 14 35 37](https://cloud.githubusercontent.com/assets/233676/9521807/ef65674c-4cc8-11e5-83ee-4f977ca4e185.png)

## After

![screen shot 2015-08-27 at 14 35 24](https://cloud.githubusercontent.com/assets/233676/9521810/f59ada16-4cc8-11e5-865e-9068d54fdb4b.png)


