### PR TITLE
Fix postal address print styles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ else
     gem 'gds-api-adapters', '20.1.1'
 end
 
-gem 'govuk_frontend_toolkit', "1.3.0"
+gem 'govuk_frontend_toolkit', '4.3.0'
 
 group :development, :test do
   gem 'rspec-rails', '2.14.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
-    govuk_frontend_toolkit (1.3.0)
+    govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.2)
@@ -121,7 +121,7 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     safe_yaml (1.0.3)
-    sass (3.3.8)
+    sass (3.4.19)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -171,7 +171,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   capybara (= 2.3.0)
   gds-api-adapters (= 20.1.1)
-  govuk_frontend_toolkit (= 1.3.0)
+  govuk_frontend_toolkit (= 4.3.0)
   logstasher (= 0.5.3)
   plek (~> 1.11)
   rails (= 4.1.11)

--- a/app/assets/stylesheets/views/_contact-show.scss
+++ b/app/assets/stylesheets/views/_contact-show.scss
@@ -71,7 +71,7 @@
       &:last-child {
         margin-bottom: $gutter;
       }
-      
+
       h3 {
         @include bold-24;
         margin-bottom: $gutter;
@@ -139,10 +139,6 @@
   .vcard {
     @include core-19;
     margin-bottom: $gutter;
-    span {
-      display: block;
-      margin-bottom: 0;
-    }
   }
 
   .beta-wrapper {

--- a/app/views/contacts/_post_address.html.erb
+++ b/app/views/contacts/_post_address.html.erb
@@ -4,12 +4,12 @@
   </div>
 <% end %>
 <div class="vcard">
-  <h3 class="fn"><%= post_address.title %></h3>
-  <span class="street-address"><%= post_address.street_address %></span>
-  <span class="locality"><%= post_address.locality %></span>
-  <span class="region"><%= post_address.region %></span>
-  <span class="postal-code"><%= post_address.postal_code %></span>
+  <div class="fn"><%= post_address.title %></div>
+  <div class="street-address"><%= post_address.street_address %></div>
+  <div class="locality"><%= post_address.locality %></div>
+  <div class="region"><%= post_address.region %></div>
+  <div class="postal-code"><%= post_address.postal_code %></div>
   <% if post_address.world_location.present? %>
-  <span class="country-name"><%= post_address.world_location %></span>
+  <div class="country-name"><%= post_address.world_location %></div>
   <% end %>
 </div>


### PR DESCRIPTION
When printing, each part of the address was appearing on a single line, and the first line appeared above it as a header. Anyone printing these pages and then transcribing the address would likely send things to the wrong place.

* Don’t use styled spans, use divs (empty divs will have a zero height, whereas spans with line breaks would create new lines for empty parts)
* Don’t use a heading for the title
* Bump govuk_frontend_toolkit

https://trello.com/c/jT7QTzBb/145-fix-print-styles-on-addresses-medium

## Before
<img width="601" alt="screen shot 2015-10-29 at 16 00 30" src="https://cloud.githubusercontent.com/assets/319055/10824001/3ef26d14-7e56-11e5-83cb-d9f301639c4a.png">

## After
<img width="599" alt="screen shot 2015-10-29 at 16 00 14" src="https://cloud.githubusercontent.com/assets/319055/10824000/3eef250a-7e56-11e5-83a7-ac95bab029bd.png">