### PR TITLE
Remove hard coded font size - fall back to inherited

### DIFF
--- a/app/assets/stylesheets/views/_contact-show.scss
+++ b/app/assets/stylesheets/views/_contact-show.scss
@@ -101,10 +101,6 @@
                 color: inherit;
               }
 
-              @include media(mobile) {
-                padding: 0;
-                font-size: 24px;
-              }
             }
           }
         }


### PR DESCRIPTION
This PR stops phone numbers from going *up* in font size on mobile, rather than down, as they should.