### PR TITLE
Add contract tests against content schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,7 @@ group :development, :test do
   gem 'capybara', '2.3.0'
   gem 'webmock', '~> 1.18.0', :require => false
 
+  gem 'govuk-content-schema-test-helpers', '1.3.0'
+
   gem 'simplecov-rcov', '0.2.3', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
+    addressable (2.3.8)
     airbrake (4.0.0)
       builder
       multi_json
@@ -55,6 +55,8 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
+    govuk-content-schema-test-helpers (1.3.0)
+      json-schema (~> 2.5.1)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -62,6 +64,8 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     kgio (2.9.2)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -171,6 +175,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   capybara (= 2.3.0)
   gds-api-adapters (= 20.1.1)
+  govuk-content-schema-test-helpers (= 1.3.0)
   govuk_frontend_toolkit (= 4.3.0)
   logstasher (= 0.5.3)
   plek (~> 1.11)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,4 +6,8 @@ export RAILS_ENV=test
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
-bundle exec rake
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+
+GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas COVERAGE=on bundle exec rake

--- a/spec/contracts/govuk_content_schemas_spec.rb
+++ b/spec/contracts/govuk_content_schemas_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe "Schema compatibility", type: :request do
+  include GdsApi::TestHelpers::ContentStore
+
+  all_examples_for_supported_formats = GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(%w{
+    contact
+  })
+  
+  all_examples_for_supported_formats.each do |example|
+    content_item = JSON.parse(example)
+
+    it "can handle a request for #{content_item["base_path"]}" do
+      content_store_has_item(content_item['base_path'], content_item)
+
+      get content_item['base_path']
+      expect(response.status).to eq(200)
+      assert_select 'title', Regexp.new(Regexp.escape(content_item['title']))
+    end
+  end
+end

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,0 +1,6 @@
+require 'govuk-content-schema-test-helpers'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'frontend'
+  config.project_root = Rails.root
+end


### PR DESCRIPTION
Any feedback welcome!

Inspired by documentation for `govuk-content-schema-helpers` (https://github.com/alphagov/govuk-content-schema-test-helpers/blob/master/README.md).
File structure similar to implementation of contract testing for `manuals-frontend`