### PR TITLE
Fix the CI build for the content_schemas jenkins-schema.sh

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -38,8 +38,7 @@ git checkout $SCHEMA_GIT_COMMIT
 cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test bundle exec rake ci:setup:rspec
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake spec:contracts
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake
 
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"


### PR DESCRIPTION
- This was causing upstream builds to fail because, embarrassingly, it
  didn't pass because it was calling the wrong thing. The perils of copy
  and paste from different projects! Thanks, Tijmen!

Related: https://github.com/alphagov/contacts-frontend/pull/38