### PR TITLE
Use an organisation's title in breadcrumbs instead of its abbreviation

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -7,11 +7,11 @@ class ContactPresenter
   end
 
   PASS_THROUGH_KEYS = [
-    :title, :details, :web_url
+    :title, :details, :links, :web_url
   ]
 
   PASS_THROUGH_DETAILS_KEYS = [
-    :description, :organisation, :query_response_time,
+    :description, :query_response_time,
     :more_info_contact_form, :more_info_email_address, :more_info_post_address, :more_info_phone_number
   ]
 
@@ -45,7 +45,8 @@ class ContactPresenter
   end
 
   def organisation
-    OpenStruct.new(details['organisation'])
+    # The only organisation in here is HMRC, so call `.first` on the array.
+    links.fetch("organisations", []).map { |organisation| OpenStruct.new(organisation) }.first
   end
 
   def slug
@@ -63,4 +64,3 @@ class ContactPresenter
   end
 
 end
-

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -4,14 +4,14 @@
   <% end %>
 <% end %>
 
-<% content_for :page_title, "#{@contact.title} - Contact #{organisation.abbreviation}" %>
+<% content_for :page_title, "#{@contact.title} - Contact #{organisation.title}" %>
 
 <% content_for :breadcrumbs do %>
   <li>
-    <%= link_to organisation.title, "/government/organisations/#{organisation.slug}" %>
+    <%= link_to organisation.title, organisation.base_path %>
   </li>
   <li>
-    <%= link_to "Contact #{organisation.abbreviation}", "/government/organisations/#{organisation.slug}/contact" %>
+    <%= link_to "Contact #{organisation.title}", "#{organisation.base_path}/contact" %>
   </li>
 <% end %>
 

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -9,14 +9,14 @@ feature "Showing a contact page" do
 
     visit(path)
 
-    expect(page).to have_title 'Annual Tax on Enveloped Dwellings - Contact HMRC - GOV.UK'
+    expect(page).to have_title 'Annual Tax on Enveloped Dwellings - Contact HM Revenue & Customs - GOV.UK'
     expect(page).to have_selector("meta[name='description'][content='Help about ATED (previously called Annual Residential Property Tax), who needs to submit a return and how to make a payment']", visible: false)
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
     expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")
     expect_links("#global-breadcrumb", {
       "Home" => "/",
       "HM Revenue & Customs" => "/government/organisations/hm-revenue-customs",
-      "Contact HMRC" => "/government/organisations/hm-revenue-customs/contact",
+      "Contact HM Revenue & Customs" => "/government/organisations/hm-revenue-customs/contact",
     })
     expect_links(".quick-links", {
       "Annual Tax on Enveloped Dwellings" => "http://www.hmrc.gov.uk/ated/index.htm",

--- a/spec/fixtures/content_store/hmrc_ated.json
+++ b/spec/fixtures/content_store/hmrc_ated.json
@@ -20,6 +20,16 @@
         "api_url": "http://www.hmrc.gov.uk/api/ated/another.json",
         "web_url": "http://www.hmrc.gov.uk/ated/another.htm"
       }
+    ],
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en"
+      }
     ]
   },
   "details": {

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -42,8 +42,10 @@ describe ContactPresenter do
     expect(contact.email_addresses.length).to eq(0)
   end
 
-  it "should access Organisation as an OpenStruct" do
-    expect(contact.organisation.abbreviation).to eq('HMRC')
-    expect(contact.organisation.slug).to eq('hm-revenue-customs')
+  it "should access Organisations from the links hash (with `base_path` and `content_id`)" do
+    expect(contact.organisation.title).to eq('HM Revenue & Customs')
+    expect(contact.organisation.base_path).to eq('/government/organisations/hm-revenue-customs')
+    expect(contact.organisation.content_id).to eq('6667cce2-e809-4e21-ae09-cb0bdc1ddda3')
+    expect(contact.organisation.abbreviation).to be_nil
   end
 end


### PR DESCRIPTION
- The use of the organisation's abbreviation (HMRC instead of HM Revenue
  and Customs) was complicating our content schema unnecessarily and
  forcing us to still use the organisation data from Whitehall, not the
  new world content-store, as it contained the `abbreviation` field we
  required. This change enables us to also change the organisations data
  to fetch from the `links`, not the details.
- Visually, the changes look OK, and Mark S. has approved this approach.

Before:

![screen shot 2016-01-08 at 15 46 09](https://cloud.githubusercontent.com/assets/355033/12201952/05d0c4ee-b61f-11e5-89a5-9baba6264f09.png)


After:

![screen shot 2016-01-08 at 15 45 53](https://cloud.githubusercontent.com/assets/355033/12201958/0c189e6c-b61f-11e5-83d7-60ed791c41ee.png)


(This will need a staged deploy with https://github.com/alphagov/contacts-admin/pull/219, after running the rake task over there so that all contacts have organisation `content_id`s, so that nothing breaks for users. Tested on Preview, with the contacts-admin stuff already done, and it's successful.)

(Trello:
https://trello.com/c/lIuKYwFE/235-simplify-contacts-admin-and-the-content-schema-by-removing-org-abbr-from-breadcrumbs-and-instead-using-the-full-organisation-nam.)