### PR TITLE
Use GA component to track format and organisation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
   <%= csrf_meta_tags %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @contact.contact } %>
   <%= yield :extra_headers %>
 </head>
 <body class="contacts-body">


### PR DESCRIPTION
For https://trello.com/c/ALk6AOEN/215-contacts-add-google-analytics-using-the-new-component

This adds tracking for `format` (dimension 2) and `organisation` (dimension 9) to the app, using the [google analytics component](https://github.com/alphagov/static/blob/master/app/views/govuk_component/analytics_meta_tags.raw.html.erb).

The following Markup is generated (truncated):

```
<meta content="authenticity_token" name="csrf-param">
<meta content="YEUU36M7scIpSbH69R/DnRmgyPJzOGVlBcN4/mwsU/Q=" name="csrf-token">
<meta name="govuk:format" content="contact">
<meta name="govuk:analytics:organisations" content="&lt;D25&gt;">
<meta name="description" content="Call or write to HMRC if you're an aircraft operator and need help with Air Passenger Duty, including registering and making payments and returns
">
<!--[if IE 6]><link href="http://assets-origin.dev.gov.uk/contacts-frontend/application-ie6.self.css?body=1" media="screen" rel="stylesheet" /><![endif]--><!--[if IE 7]><link href="http://assets-origin.dev.gov.uk/contacts-frontend/application-ie7.self.css?body=1" media="screen" rel="stylesheet" /><![endif]--><!--[if IE 8]><link href="http://assets-origin.dev.gov.uk/contacts-frontend/application-ie8.self.css?body=1" media="screen" rel="stylesheet" /><![endif]--><meta name="govuk:rendering-application" content="contacts-frontend">
```

Google Analytics Output using "Google Analytics Debugger" Chrome App:

<img width="609" alt="screen shot 2016-01-12 at 11 34 37" src="https://cloud.githubusercontent.com/assets/5112255/12262575/a4e4d95e-b920-11e5-9c29-768280ac2fda.png">