### PR TITLE
Add webchat to VAT enquiries page and remove opening times

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -17,7 +17,7 @@
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1012;
-  // entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] =;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] = 1028;
 
   var API_URL = 'https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/';
   var OPEN_CHAT_URL = function (entryPointID) {

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -69,7 +69,7 @@ class ContactPresenter
       # '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
       # '/government/organisations/hm-revenue-customs/contact/self-assessment',
       # '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
-      # '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
+      '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
     ]
     whitelisted_paths.include?(@contact.base_path)
   end

--- a/app/views/contacts/_contact_details.html.erb
+++ b/app/views/contacts/_contact_details.html.erb
@@ -38,9 +38,6 @@
       <p class="js-webchat-advisers-available hidden">
         Advisers are available to chat. <a href="#" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
       </p>
-      <h4>Opening times:</h4>
-      <p>8am to 8pm, Monday to Friday<br>8am to 4pm Saturday</p>
-      <p>Closed Sundays, Christmas Day, Boxing Day and New Year’s Day</p>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
This enables the new webchat for the VAT enquiries page.

It also removes the opening times for webchat. This is because the current opening times of HMRC webchat are more flexible than suggested. Sometimes webchat is open earlier or later in the day, and at times may be closed while advisors handle other channels. This means the published opening times are misleading and causing confusion.

Should be merged alongside https://github.com/alphagov/static/pull/828