### PR TITLE
Enable webchat contact method on Tax Credits page

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -16,7 +16,7 @@
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/national-insurance-numbers'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment'] =;
-  // entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1012;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1016;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] = 1028;
 
   var API_URL = 'https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/';

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -68,7 +68,7 @@ class ContactPresenter
       # '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
       # '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
       # '/government/organisations/hm-revenue-customs/contact/self-assessment',
-      # '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
+      '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
     ]
     whitelisted_paths.include?(@contact.base_path)


### PR DESCRIPTION
This pull request enables the HMRC webchat contact method on the Tax Credits contact page.

This will need to be deployed alongside a change in static to disable the original webchat implementation on this page (https://github.com/alphagov/static/pull/829).