### PR TITLE
Enable webchat on Self Assessment enquiries page

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -15,7 +15,7 @@
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk'] = 1026;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/national-insurance-numbers'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] =;
-  // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment'] =;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment'] = 1004;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1012;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] = 1028;
 

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -67,7 +67,7 @@ class ContactPresenter
       '/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk',
       # '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
       # '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
-      # '/government/organisations/hm-revenue-customs/contact/self-assessment',
+      '/government/organisations/hm-revenue-customs/contact/self-assessment',
       # '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
     ]


### PR DESCRIPTION
**Not to be merged until 7 September**

This pull request enables HMRC webchat as a contact method on the Self Assessment enquiries page.

It needs to be deployed alongside a change in static to disable the original webchat service (https://github.com/alphagov/static/pull/830).