### PR TITLE
Enable webchat on NINO & SA online pages

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -13,8 +13,8 @@
   var entryPointIDs = {};
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/child-benefit'] = 1027;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk'] = 1026;
-  // entryPointIDs['/government/organisations/hm-revenue-customs/contact/national-insurance-numbers'] =;
-  // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] =;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/national-insurance-numbers'] = 1021;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] = 1003;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/self-assessment'] =;
   // entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1012;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] = 1028;

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -65,8 +65,8 @@ class ContactPresenter
     whitelisted_paths = [
       '/government/organisations/hm-revenue-customs/contact/child-benefit',
       '/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk',
-      # '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
-      # '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
+      '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
+      '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
       # '/government/organisations/hm-revenue-customs/contact/self-assessment',
       # '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries',


### PR DESCRIPTION
**Not to be deployed until 12 September**

This enables webchat on the National Insurance Number and Self Assessment online enquiries contact pages.

It should be deployed alongside a change in static to disable the original webchat implementation on these pages (https://github.com/alphagov/static/pull/831).