### PR TITLE
Use new GDS API Adapters behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'unicorn', '4.8.3'
 if ENV['API_DEV']
     gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-    gem 'gds-api-adapters', '33.2.0'
+    gem 'gds-api-adapters', '36.0.0'
 end
 
 gem 'govuk_frontend_toolkit', '4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (33.2.0)
+    gds-api-adapters (36.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -250,7 +250,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   capybara (= 2.7.1)
-  gds-api-adapters (= 33.2.0)
+  gds-api-adapters (= 36.0.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint (= 1.2.0)
   govuk_frontend_toolkit (= 4.3.0)
@@ -267,3 +267,6 @@ DEPENDENCIES
   unicorn (= 4.8.3)
   web-console (~> 2.0)
   webmock (~> 1.18.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ private
 
   def error_404; error 404; end
 
+  def error_410; error 410; end
+
   def error(status_code, exception = nil)
     if exception && defined? Airbrake
       env["airbrake.error_id"] = notify_airbrake(exception)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -14,6 +14,8 @@ class ContactsController < ApplicationController
       @contact = ContactPresenter.new(obj)
     rescue GdsApi::HTTPNotFound
       error_404 && return
+    rescue GdsApi::HTTPGone
+      error_410 && return
     end
   end
 

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -71,6 +71,6 @@ class ContactPresenter
       '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
     ]
-    whitelisted_paths.include?(@contact.base_path)
+    whitelisted_paths.include?(@contact["base_path"])
   end
 end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,3 +1,4 @@
 GdsApi.configure do |config|
   config.always_raise_for_not_found = true
+  config.hash_response_for_requests = true
 end

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -29,6 +29,15 @@ feature "Showing a contact page" do
     expect(page.status_code).to eq(404)
   end
 
+  it "should 410 for a gone item in the content-store" do
+    path = '/government/organisations/hm-revenue-customs/contact/medieval-tax'
+
+    content_store_has_gone_item(path)
+
+    visit(path)
+    expect(page.status_code).to eq(410)
+  end
+
   it "should render web chat" do
     path = "/government/organisations/hm-revenue-customs/contact/child-benefit"
 


### PR DESCRIPTION
- Trello card:  https://trello.com/c/B5z6Dq8q/495.
- Some old behaviour has been deprecated in [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) so we are updating this app to comply with this before it becomes the default. Firstly, a GdsApi::NotFound error is now raised when the server returns a 404 or 410.  Secondly, requests now return a hash instead of an OpenStruct.  We have now opted in to this new behaviour.