### PR TITLE
The index page is now served by finder-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Contacts are published by [alphagov/contacts-admin](https://github.com/alphagov/
 A contact page:
 - https://www.gov.uk/government/organisations/hm-revenue-customs/contact/alcohol-duties-national-registration-unit
 
-Note that the index page is served by [contacts-admin](https://github.com/alphagov/contacts-admin):
+Note that the index page is served by
+[finder-frontend](https://github.com/alphagov/finder-frontend):
 - https://www.gov.uk/government/organisations/hm-revenue-customs/contact
-
 
 ### Dependencies
 


### PR DESCRIPTION
Update the README to reflect that.

PR with that change: https://github.com/alphagov/contacts-admin/pull/249