### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -18,6 +18,6 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
 fi
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas COVERAGE=on bundle exec rake


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Contacts Frontend app that don't
work with the currently deployed govuk-content-schemas (this changes
comes from GOV.UK RFC 59).