### PR TITLE
Enable HMRC webchat for specialist tax trusts

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -20,6 +20,7 @@
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries'] = 1016;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/vat-enquiries'] = 1028;
   entryPointIDs['/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries'] = 1034;
+  entryPointIDs['/government/organisations/hm-revenue-customs/contact/trusts'] = 1036;
 
   var API_URL = 'https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/';
   var OPEN_CHAT_URL = function (entryPointID) {

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -72,6 +72,7 @@ class ContactPresenter
       '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
       '/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries',
+      '/government/organisations/hm-revenue-customs/contact/trusts',
     ]
     whitelisted_paths.include?(@contact["base_path"])
   end


### PR DESCRIPTION
This should go out on the 15th of December.

Trello card: https://trello.com/c/dtueOo2D/530-click-to-chat