### PR TITLE
Render breadcrumbs using the govuk_component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 gem 'uglifier', '>= 2.7.2'
 
 gem 'plek', '~> 1.11'
-gem 'slimmer', '9.0.1'
+gem 'slimmer', '~> 10.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,13 +202,13 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.0.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     spring (1.7.2)
@@ -261,7 +261,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (= 3.5.1)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 9.0.1)
+  slimmer (~> 10.0)
   spring
   uglifier (>= 2.7.2)
   unicorn (= 4.8.3)
@@ -269,4 +269,4 @@ DEPENDENCIES
   webmock (~> 1.18.0)
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   protect_from_forgery with: :exception
 

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -6,14 +6,22 @@
 
 <% content_for :page_title, "#{@contact.title} - Contact #{organisation.title}" %>
 
-<% content_for :breadcrumbs do %>
-  <li>
-    <%= link_to organisation.title, organisation.base_path %>
-  </li>
-  <li>
-    <%= link_to "Contact #{organisation.title}", "#{organisation.base_path}/contact" %>
-  </li>
-<% end %>
+<%= render partial: "govuk_component/breadcrumbs", locals: {
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/",
+    },
+    {
+      title: organisation.title,
+      url: organisation.base_path,
+    },
+    {
+      title: "Contact #{organisation.title}",
+      url: "#{organisation.base_path}/contact",
+    },
+  ]
+} %>
 
 <div class="grid-row">
 <main id="content" class="contact-show">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,16 +11,7 @@
   <%= yield :extra_headers %>
 </head>
 <body class="contacts-body">
-
-<div id="global-breadcrumb" class="header-context group">
-  <ol class="group">
-    <li>
-      <%= link_to "Home", '/' %>
-    </li>
-    <%= yield :breadcrumbs %>
-  </ol>
-</div>
-
+<div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
 <div id="wrapper" class="contacts-wrapper">
   <div class="contacts-content">
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >

--- a/spec/contracts/govuk_content_schemas_spec.rb
+++ b/spec/contracts/govuk_content_schemas_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Schema compatibility", type: :request do
     content_item = JSON.parse(example)
 
     it "can handle a request for #{content_item['base_path']}" do
+      stub_shared_component_locales
       content_store_has_item(content_item['base_path'], content_item)
 
       get content_item['base_path']

--- a/spec/features/contact_page_spec.rb
+++ b/spec/features/contact_page_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 feature "Showing a contact page" do
+  before do
+    stub_shared_component_locales
+  end
+
   it "renders a contact page" do
     path = '/government/organisations/hm-revenue-customs/contact/annual-tax-on-enveloped-dwellings-ated'
 
@@ -9,7 +13,7 @@ feature "Showing a contact page" do
     # guaranteed to get 900, it could 899 if the request takes longer than a
     # second to process.
     # See https://github.com/alphagov/gds-api-adapters/blob/45fdbf98398f1fab97ac26164db1621d3390aec5/lib/gds_api/response.rb#L57-L67
-    GdsApi::Response.any_instance.stub(expires_in: 900)
+    allow_any_instance_of(GdsApi::Response).to receive(:expires_in).and_return(900)
 
     content_store_has_item(path, read_content_store_fixture('hmrc_ated'))
 
@@ -19,9 +23,15 @@ feature "Showing a contact page" do
     expect(page).to have_selector("meta[name='description'][content='Help about ATED (previously called Annual Residential Property Tax), who needs to submit a return and how to make a payment']", visible: false)
     expect(page).to have_content("Annual Tax on Enveloped Dwellings")
     expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")
-    expect_links("#global-breadcrumb", "Home" => "/",
-      "HM Revenue & Customs" => "/government/organisations/hm-revenue-customs",
-      "Contact HM Revenue & Customs" => "/government/organisations/hm-revenue-customs/contact")
+
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+
+    within(shared_component_selector('breadcrumbs')) do
+      expect(page).to have_content('Home')
+      expect(page).to have_content('HM Revenue & Customs')
+      expect(page).to have_content('Contact HM Revenue & Customs')
+    end
+
     expect_links(".quick-links", "Annual Tax on Enveloped Dwellings" => "http://www.hmrc.gov.uk/ated/index.htm")
     expect_links(".related-links", "Annual tax on enveloped dwellings contact" => "http://www.hmrc.gov.uk/ated/contact.htm",
       "Another contact" => "http://www.hmrc.gov.uk/ated/another.htm")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'webmock/rspec'
 require 'slimmer/test'
+require 'slimmer/test_helpers/govuk_components'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -19,6 +20,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  include Slimmer::TestHelpers::GovukComponents
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
- There is no change to the appearance or text of the breadcrumbs, but
they are now rendered by the govuk_component.

[Trello card](https://trello.com/c/TekeTJ9Y/401-use-govuk-component-in-contacts-frontend)

#### Before (full width and mobile width)
![screen shot 2017-01-11 at 12 39 23](https://cloud.githubusercontent.com/assets/12881990/21849154/4648f12c-d7fc-11e6-8d20-03d136006fe9.png)
![screen shot 2017-01-11 at 12 40 04](https://cloud.githubusercontent.com/assets/12881990/21849157/492012a4-d7fc-11e6-9bcc-de4dd73a8ed4.png)

#### After (full width and mobile width)
![screen shot 2017-01-11 at 12 37 18](https://cloud.githubusercontent.com/assets/12881990/21849079/d5e4f0b6-d7fb-11e6-9c51-d509681b5c94.png)
![screen shot 2017-01-11 at 12 37 47](https://cloud.githubusercontent.com/assets/12881990/21849100/f8c695bc-d7fb-11e6-9981-2027095874c7.png)

