### PR TITLE
Update domains used for schema tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.alphagov.co.uk
-export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+export GOVUK_APP_DOMAIN=test.gov.uk
+export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env
 
 function github_status {


### PR DESCRIPTION
As of https://github.com/alphagov/contacts-frontend/pull/67, `slimmer` now requests locale data, which is stubbed out in the tests using `stub_shared_component_locales`. This method stubs all calls to `gov.uk` domains, while the schema test runner still uses the old `alphagov.co.uk` domains. Due to this, schema tests are not passing.