### PR TITLE
Move test env vars to spec helper

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.gov.uk
-export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env
 
 function github_status {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.start 'rails'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV["GOVUK_WEBSITE_ROOT"] = "http://www.test.gov.uk"
+ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
+ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
These env vars should apply across tests, not just for Jenkins schema tests.